### PR TITLE
Updated wiki links to new domain

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -17,20 +17,20 @@ import FabricIcon from "../components/FabricIcon.vue";
 
 const featureLinks =
   ref(`\n\n[1]: https://github.com/Fabulously-Optimized/fabulously-optimized/blob/main/INCLUDED-MODS.md#smooth
-[2]: https://fabulously-optimized.gitbook.io/modpack/readme/give-up-optifine
-[3]: https://fabulously-optimized.gitbook.io/modpack/readme/free-cape
+[2]: https://wiki.download.fo/readme/give-up-optifine
+[3]: https:/wiki.download.fo/readme/free-cape
 [4]: https://github.com/Fabulously-Optimized/fabulously-optimized/blob/main/INCLUDED-MODS.md#functional
 [5]: https://github.com/Fabulously-Optimized/fabulously-optimized#downloads
 [6]: https://github.com/Fabulously-Optimized/fabulously-optimized/blob/main/CHANGELOG.md
-[7]: https://fabulously-optimized.gitbook.io/modpack/readme/update-instructions
-[8]: https://fabulously-optimized.gitbook.io/modpack/readme/adding-more-mods
+[7]: https://wiki.download.fo/readme/update-instructions
+[8]: https://wiki.download.fo/readme/adding-more-mods
 [9]: https://github.com/Fabulously-Optimized/fabulously-optimized
-[10]: https://fabulously-optimized.gitbook.io/modpack/readme/language-support
+[10]: https://wiki.download.fo/readme/language-support
 [11]: https://discord.gg/fabulously-optimized-859124104644788234
-[12]: https://fabulously-optimized.gitbook.io/modpack
+[12]: https://wiki.download.fo
 [13]: https://github.com/Fabulously-Optimized/fabulously-optimized/blob/main/INCLUDED-MODS.md
 [14]: https://github.com/Fabulously-Optimized/fabulously-optimized/blob/main/CONTRIBUTING.md
-[15]: https://fabulously-optimized.gitbook.io/modpack/readme/server-setup
+[15]: https://wiki.download.fo/readme/server-setup
 [16]: https://www.bisecthosting.com/clients/aff.php?aff=2604
 [17]: https://github.com/Fabulously-Optimized/fabulously-optimized#disclaimers`);
 


### PR DESCRIPTION
Updated wiki links from the old domain to `wiki.download.fo`.