### PR TITLE
Change footer notice

### DIFF
--- a/lang/en_us.json
+++ b/lang/en_us.json
@@ -6,7 +6,7 @@
   "footer.header.discuss": "Discuss",
   "footer.header.download": "Download",
   "footer.links.translate": "Translate",
-  "footer.legal_notice": "Fabulously Optimized is not affiliated with Mojang Studios, Microsoft or Modrinth.",
+  "footer.legal_notice": "Fabulously Optimized is not affiliated with Mojang Studios or Microsoft.",
   "content.contributors.columned-hero.title": "These people are truly amazing...",
   "content.contributors.columned-hero.subtitle": "Fabulously Optimized is a community effort, and we couldn't have done it without these people.",
   "content.contributors.org": "Organization Members",


### PR DESCRIPTION
There's not really a need to mention the lack of affiliation with Modrinth, and if would, it should also mention CurseForge, GitHub etc. Better to just remove it.